### PR TITLE
adds version req for atcursor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     yaml,
     backports,
     magrittr,
-    atcursor,
+    atcursor (>= 0.0.2),
     clipr,
     curl,
     gh,


### PR DESCRIPTION
So it turns out if you have an old version of atcursor installed, then the right function for rmdgh isn't exported, and the jump_to_issue* will die b/c of exporting.

I think this will work as long as someone used the r-universe installation method.