### PR TITLE
depend on rmarkdown 2.15 or greater

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Imports:
     fs,
     gert,
     reprex,
-    rmarkdown,
+    rmarkdown (>= 2.15),
     xfun,
     yaml,
     backports,


### PR DESCRIPTION
There was a new option added in rmarkdown gh_markdown docs, and if using 2.14, it will complain upon trying to render the gh_markdown document.

This is to try and keep that from happening.

I keep getting bit by this as my old renv installs all have rmarkdown 2.14, and I go to render my issue, and I get an error about "webtex" or some weird thing. Upgrading to latest 2.16 fixes the issue, and looking at [rmarkdown releases](https://github.com/rstudio/rmarkdown/releases/tag/v2.15), the updated field was introduced in 2.15, so hopefully this fixes that issue appearing. :crossed_fingers: 